### PR TITLE
feat: add initialization checks to IMT structures

### DIFF
--- a/packages/imt/contracts/InternalBinaryIMT.sol
+++ b/packages/imt/contracts/InternalBinaryIMT.sol
@@ -7,6 +7,7 @@ import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "./Constants.sol";
 // Each incremental tree has certain properties and data that will
 // be used to add new leaves.
 struct BinaryIMTData {
+    bool initialized; // Flag to track if the tree has been initialized
     uint256 depth; // Depth of the tree (levels - 1).
     uint256 root; // Root hash of the tree.
     uint256 numberOfLeaves; // Number of leaves of the tree.
@@ -24,6 +25,8 @@ error NewLeafCannotEqualOldLeaf();
 error LeafDoesNotExist();
 error LeafIndexOutOfRange();
 error WrongMerkleProofPath();
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 /// @title Incremental binary Merkle tree.
 /// @dev The incremental tree allows to calculate the root hash each time a leaf is added, ensuring
@@ -105,6 +108,9 @@ library InternalBinaryIMT {
     /// @param depth: Depth of the tree.
     /// @param zero: Zero value to be used.
     function _init(BinaryIMTData storage self, uint256 depth, uint256 zero) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }        
         if (zero >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
         } else if (depth <= 0 || depth > MAX_DEPTH) {
@@ -123,9 +129,13 @@ library InternalBinaryIMT {
         }
 
         self.root = zero;
+        self.initialized = true;
     }
 
     function _initWithDefaultZeroes(BinaryIMTData storage self, uint256 depth) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
         if (depth <= 0 || depth > MAX_DEPTH) {
             revert DepthNotSupported();
         }
@@ -134,13 +144,18 @@ library InternalBinaryIMT {
         self.useDefaultZeroes = true;
 
         self.root = _defaultZero(depth);
+        self.initialized = true;
     }
 
     /// @dev Inserts a leaf in the tree.
     /// @param self: Tree data.
     /// @param leaf: Leaf to be inserted.
     function _insert(BinaryIMTData storage self, uint256 leaf) internal returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         uint256 depth = self.depth;
+        
 
         if (leaf >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
@@ -185,6 +200,9 @@ library InternalBinaryIMT {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         if (newLeaf == leaf) {
             revert NewLeafCannotEqualOldLeaf();
         } else if (newLeaf >= SNARK_SCALAR_FIELD) {
@@ -237,6 +255,9 @@ library InternalBinaryIMT {
         uint256[] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         _update(self, leaf, self.useDefaultZeroes ? Z_0 : self.zeroes[0], proofSiblings, proofPathIndices);
     }
 

--- a/packages/imt/contracts/InternalQuinaryIMT.sol
+++ b/packages/imt/contracts/InternalQuinaryIMT.sol
@@ -7,6 +7,7 @@ import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "./Constants.sol";
 // Each incremental tree has certain properties and data that will
 // be used to add new leaves.
 struct QuinaryIMTData {
+    bool initialized; // Flag to track if the tree has been initialized
     uint256 depth; // Depth of the tree (levels - 1).
     uint256 root; // Root hash of the tree.
     uint256 numberOfLeaves; // Number of leaves of the tree.
@@ -22,6 +23,8 @@ error NewLeafCannotEqualOldLeaf();
 error LeafDoesNotExist();
 error LeafIndexOutOfRange();
 error WrongMerkleProofPath();
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 /// @title Incremental quinary Merkle tree.
 /// @dev The incremental tree allows to calculate the root hash each time a leaf is added, ensuring
@@ -32,6 +35,9 @@ library InternalQuinaryIMT {
     /// @param depth: Depth of the tree.
     /// @param zero: Zero value to be used.
     function _init(QuinaryIMTData storage self, uint256 depth, uint256 zero) internal {
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
         if (zero >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
         } else if (depth <= 0 || depth > MAX_DEPTH) {
@@ -59,13 +65,18 @@ library InternalQuinaryIMT {
         }
 
         self.root = zero;
+        self.initialized = true;
     }
 
     /// @dev Inserts a leaf in the tree.
     /// @param self: Tree data.
     /// @param leaf: Leaf to be inserted.
     function _insert(QuinaryIMTData storage self, uint256 leaf) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         uint256 depth = self.depth;
+
 
         if (leaf >= SNARK_SCALAR_FIELD) {
             revert ValueGreaterThanSnarkScalarField();
@@ -115,6 +126,9 @@ library InternalQuinaryIMT {
         uint256[4][] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         if (newLeaf == leaf) {
             revert NewLeafCannotEqualOldLeaf();
         } else if (newLeaf >= SNARK_SCALAR_FIELD) {
@@ -173,6 +187,9 @@ library InternalQuinaryIMT {
         uint256[4][] calldata proofSiblings,
         uint8[] calldata proofPathIndices
     ) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         _update(self, leaf, self.zeroes[0], proofSiblings, proofPathIndices);
     }
 

--- a/packages/lazy-imt/contracts/InternalLazyIMT.sol
+++ b/packages/lazy-imt/contracts/InternalLazyIMT.sol
@@ -5,10 +5,14 @@ import {PoseidonT3} from "poseidon-solidity/PoseidonT3.sol";
 import {SNARK_SCALAR_FIELD, MAX_DEPTH} from "./Constants.sol";
 
 struct LazyIMTData {
+    bool initialized; // Flag to track if the tree has been initialized
     uint40 maxIndex;
     uint40 numberOfLeaves;
     mapping(uint256 => uint256) elements;
 }
+
+error TreeAlreadyInitialized();
+error TreeNotInitialized();
 
 library InternalLazyIMT {
     uint40 internal constant MAX_INDEX = (1 << 32) - 1;
@@ -86,11 +90,18 @@ library InternalLazyIMT {
 
     function _init(LazyIMTData storage self, uint8 depth) internal {
         require(depth <= MAX_DEPTH, "LazyIMT: Tree too large");
+        if (self.initialized) {
+            revert TreeAlreadyInitialized();
+        }
         self.maxIndex = uint40((1 << depth) - 1);
         self.numberOfLeaves = 0;
+        self.initialized = true;
     }
 
     function _reset(LazyIMTData storage self) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         self.numberOfLeaves = 0;
     }
 
@@ -101,9 +112,12 @@ library InternalLazyIMT {
 
     function _insert(LazyIMTData storage self, uint256 leaf) internal {
         uint40 index = self.numberOfLeaves;
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         require(leaf < SNARK_SCALAR_FIELD, "LazyIMT: leaf must be < SNARK_SCALAR_FIELD");
         require(index < self.maxIndex, "LazyIMT: tree is full");
-
+        
         self.numberOfLeaves = index + 1;
 
         uint256 hash = leaf;
@@ -122,6 +136,9 @@ library InternalLazyIMT {
     }
 
     function _update(LazyIMTData storage self, uint256 leaf, uint40 index) internal {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         require(leaf < SNARK_SCALAR_FIELD, "LazyIMT: leaf must be < SNARK_SCALAR_FIELD");
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
@@ -147,6 +164,9 @@ library InternalLazyIMT {
     }
 
     function _root(LazyIMTData storage self) internal view returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         // this will always short circuit if self.numberOfLeaves == 0
         uint40 numberOfLeaves = self.numberOfLeaves;
         // dynamically determine a depth
@@ -158,6 +178,9 @@ library InternalLazyIMT {
     }
 
     function _root(LazyIMTData storage self, uint8 depth) internal view returns (uint256) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         require(depth > 0, "LazyIMT: depth must be > 0");
         require(depth <= MAX_DEPTH, "LazyIMT: depth must be <= MAX_DEPTH");
         uint40 numberOfLeaves = self.numberOfLeaves;
@@ -218,6 +241,9 @@ library InternalLazyIMT {
         uint40 index,
         uint8 depth
     ) internal view returns (uint256[] memory) {
+        if (!self.initialized) {
+            revert TreeNotInitialized();
+        }
         uint40 numberOfLeaves = self.numberOfLeaves;
         require(index < numberOfLeaves, "LazyIMT: leaf must exist");
 


### PR DESCRIPTION
Added an 'initialized' flag to BinaryIMTData, QuinaryIMTData, and LazyIMTData structures to track initialization state. Implemented checks in the _init, _insert, and other relevant functions to prevent operations on uninitialized trees, enhancing error handling with new revert errors: TreeAlreadyInitialized and TreeNotInitialized.

<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [ ] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.solidity/blob/main/CODE_OF_CONDUCT.md).
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [ ] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [ ] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
